### PR TITLE
Fix sed command to work with new config.rb.sample

### DIFF
--- a/src/first-init.command
+++ b/src/first-init.command
@@ -40,7 +40,7 @@ sed -i "" 's/#$vm_memory = 1024/$vm_memory = 512/' ~/coreos-k8s-cluster/control/
 cp ~/coreos-k8s-cluster/tmp/config.rb.sample ~/coreos-k8s-cluster/workers/config.rb
 sed -i "" 's/#$instance_name_prefix="core"/$instance_name_prefix="k8snode"/' ~/coreos-k8s-cluster/workers/config.rb
 # set nodes to 2
-sed -i "" 's/#$num_instances=1/$num_instances=2/' ~/coreos-k8s-cluster/workers/config.rb
+sed -i "" 's/[#]*$num_instances=1/$num_instances=2/' ~/coreos-k8s-cluster/workers/config.rb
 
 ###
 


### PR DESCRIPTION
This commit upstream https://github.com/coreos/coreos-vagrant/commit/c506e3d0fa1c6fe394d2430b586a735a9011552b#diff-2cc81a511006fc4be32a1ab84afd6f5bR2 broke the setup of the second worker VM. The adjusted sed command works whether or not the num_instances is commented out in the config.b.sample.
